### PR TITLE
跨媒体合并剧集、电影

### DIFF
--- a/Common/UnionFindUtility.cs
+++ b/Common/UnionFindUtility.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace MediaInfoKeeper.Common
+{
+    public static class UnionFindUtility
+    {
+        public static long Find(long x, Dictionary<long, long> parent)
+        {
+            if (!parent.TryGetValue(x, out var p))
+            {
+                parent[x] = x;
+                return x;
+            }
+
+            if (p != x)
+            {
+                parent[x] = Find(p, parent);
+            }
+
+            return parent[x];
+        }
+
+        public static void Union(long x, long y, Dictionary<long, long> parent)
+        {
+            var rootX = Find(x, parent);
+            var rootY = Find(y, parent);
+
+            if (rootX != rootY)
+            {
+                parent[rootX] = rootY;
+            }
+        }
+    }
+}

--- a/Options/EnhanceOptions.cs
+++ b/Options/EnhanceOptions.cs
@@ -168,6 +168,38 @@ namespace MediaInfoKeeper.Options
         [Description("调整新建媒体库默认设置：TMDB 优先且独占启用，图片保存到媒体文件夹，字幕下载器默认关闭，章节自动生成默认关闭，语言地区默认中国中文。")]
         public bool EnableLibrayProviderSettings { get; set; } = true;
 
+        [DisplayName("自动合并多版本")]
+        [Description("开启后自动合并相同电影/电视剧的多个版本，支持跨库操作。\n\n保存后会自动为所有电视剧库开启 Emby 的自动剧集分组。")]
+        public bool MergeMultiVersion { get; set; } = false;
+
+        public enum MergeMoviesScopeOption
+        {
+            [Description("同文件夹")]
+            FolderScope,
+            [Description("同媒体库内")]
+            LibraryScope,
+            [Description("所有电影库")]
+            GlobalScope
+        }
+
+        [DisplayName("电影合并范围")]
+        [Description("同文件夹：仅合并同文件夹下的多版本；同媒体库内：合并当前库内相同电影；所有电影库：在所有电影/混合库中查找并合并。")]
+        [VisibleCondition(nameof(MergeMultiVersion), SimpleCondition.IsTrue)]
+        public MergeMoviesScopeOption MergeMoviesPreference { get; set; } = MergeMoviesScopeOption.FolderScope;
+
+        public enum MergeSeriesScopeOption
+        {
+            [Description("同媒体库内")]
+            LibraryScope,
+            [Description("所有电视剧库")]
+            GlobalScope
+        }
+
+        [DisplayName("电视剧合并范围")]
+        [Description("同媒体库内：仅合并当前库内的相同剧集；所有电视剧库：在所有电视剧/混合库中查找并合并。\n\n选择所有电视剧库时，保存后插件会自动开启所有电视剧/混合库的 Emby 自动剧集分组选项。")]
+        [VisibleCondition(nameof(MergeMultiVersion), SimpleCondition.IsTrue)]
+        public MergeSeriesScopeOption MergeSeriesPreference { get; set; } = MergeSeriesScopeOption.LibraryScope;
+
         [DisplayName("日志来源黑名单")]
         [Description("按 logger.Name 匹配需要屏蔽的系统日志来源，支持逗号、分号或换行分隔。支持精确匹配；对于带动态后缀的来源可填写前缀，如 SessionsService-。")]
         public string SystemLogNameBlacklist { get; set; } = "HttpClient;TheMovieDb;SessionsService-;PlaystateService-;MediaInfoService-";
@@ -278,6 +310,11 @@ namespace MediaInfoKeeper.Options
             AddGroup("通知", "", 
                 nameof(EnableNotificationEnhance),
                 nameof(TakeOverSystemLibraryNew));
+            
+            AddGroup("多版本合并", "",
+                nameof(MergeMultiVersion),
+                nameof(MergeMoviesPreference),
+                nameof(MergeSeriesPreference));
             
             AddGroup("UI功能", "",
                 nameof(EnableEpisodeImageAspectRatioOptimize),

--- a/Options/Store/EnhanceOptionsStore.cs
+++ b/Options/Store/EnhanceOptionsStore.cs
@@ -35,6 +35,20 @@ namespace MediaInfoKeeper.Options.Store
                 ChineseSearch.UpdateSearchScope(next.SearchScope);
             }
 
+            if (current.MergeMultiVersion != next.MergeMultiVersion ||
+                current.MergeSeriesPreference != next.MergeSeriesPreference)
+            {
+                var pluginEnabled = Plugin.Instance?.Options?.MainPage?.PlugginEnabled ?? true;
+                MergeMultiVersion.Configure(
+                    pluginEnabled && next.MergeMultiVersion,
+                    next.MergeSeriesPreference);
+            }
+
+            if (next.MergeMultiVersion)
+            {
+                Plugin.LibraryService?.EnsureLibraryEnabledAutomaticSeriesGrouping();
+            }
+
             var isSimpleTokenizer =
                 string.Equals(ChineseSearch.CurrentTokenizerName, "simple", StringComparison.Ordinal);
             next.EnhanceChineseSearchRestore = !next.EnhanceChineseSearch && isSimpleTokenizer;

--- a/Patch/Enhance/MergeMultiVersion.cs
+++ b/Patch/Enhance/MergeMultiVersion.cs
@@ -1,0 +1,433 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using HarmonyLib;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Data;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Logging;
+using MediaBrowser.Model.Services;
+using MediaInfoKeeper.External;
+using MediaInfoKeeper.Options;
+using static MediaInfoKeeper.Options.EnhanceOptions;
+
+namespace MediaInfoKeeper.Patch
+{
+    public static class MergeMultiVersion
+    {
+        private static readonly AsyncLocal<BaseItem[]> currentAllCollectionFolders = new AsyncLocal<BaseItem[]>();
+
+        private static Harmony harmony;
+        private static ILogger logger;
+        private static MethodInfo isEligibleForMultiVersion;
+        private static MethodInfo canRefreshImage;
+        private static MethodInfo addLibrariesToPresentationUniqueKey;
+        private static MethodInfo getRefreshOptions;
+        private static bool isEnabled;
+        private static bool isPatched;
+        private static MergeSeriesScopeOption mergeSeriesPreference;
+
+        public static bool IsReady => harmony != null && (!isEnabled || isPatched);
+
+        public static void Initialize(ILogger pluginLogger, bool enable, MergeSeriesScopeOption seriesPreference)
+        {
+            if (harmony != null)
+            {
+                Configure(enable, seriesPreference);
+                return;
+            }
+
+            logger = pluginLogger;
+            isEnabled = enable;
+            mergeSeriesPreference = seriesPreference;
+            isPatched = false;
+
+            try
+            {
+                var namingAssembly = Assembly.Load("Emby.Naming");
+                var namingVersion = namingAssembly?.GetName().Version;
+                var videoListResolverType = namingAssembly?.GetType("Emby.Naming.Video.VideoListResolver");
+                if (videoListResolverType == null)
+                {
+                    FailInitialization("Emby.Naming.Video.VideoListResolver 类型缺失");
+                    return;
+                }
+
+                isEligibleForMultiVersion = PatchMethodResolver.Resolve(
+                    videoListResolverType,
+                    namingVersion,
+                    new MethodSignatureProfile
+                    {
+                        Name = "video-resolver-iseligible-exact",
+                        MethodName = "IsEligibleForMultiVersion",
+                        BindingFlags = BindingFlags.Static | BindingFlags.NonPublic,
+                        ParameterTypes = new[] { typeof(string), typeof(string) },
+                        ReturnType = typeof(bool)
+                    },
+                    logger,
+                    "MergeMultiVersion.VideoListResolver.IsEligibleForMultiVersion");
+
+                var providersAssembly = Assembly.Load("Emby.Providers");
+                var providerManagerType = providersAssembly?.GetType("Emby.Providers.Manager.ProviderManager");
+                if (providerManagerType == null)
+                {
+                    FailInitialization("Emby.Providers.Manager.ProviderManager 类型缺失");
+                    return;
+                }
+
+                canRefreshImage = PatchMethodResolver.Resolve(
+                    providerManagerType,
+                    providersAssembly?.GetName().Version,
+                    new MethodSignatureProfile
+                    {
+                        Name = "provider-canrefresh-image-exact",
+                        MethodName = "CanRefresh",
+                        BindingFlags = BindingFlags.Instance | BindingFlags.NonPublic,
+                        ParameterTypes = new[]
+                        {
+                            typeof(IImageProvider),
+                            typeof(BaseItem),
+                            typeof(LibraryOptions),
+                            typeof(ImageRefreshOptions),
+                            typeof(bool),
+                            typeof(bool)
+                        },
+                        ReturnType = typeof(bool)
+                    },
+                    logger,
+                    "MergeMultiVersion.ProviderManager.CanRefresh");
+
+                addLibrariesToPresentationUniqueKey = PatchMethodResolver.Resolve(
+                    typeof(Series),
+                    typeof(Series).Assembly.GetName().Version,
+                    new MethodSignatureProfile
+                    {
+                        Name = "series-addlibraries-exact",
+                        MethodName = "AddLibrariesToPresentationUniqueKey",
+                        BindingFlags = BindingFlags.Instance | BindingFlags.NonPublic,
+                        ParameterTypes = new[]
+                        {
+                            typeof(string),
+                            typeof(BaseItem[]),
+                            typeof(LibraryOptions),
+                            typeof(IDataContext)
+                        },
+                        ReturnType = typeof(string)
+                    },
+                    logger,
+                    "MergeMultiVersion.Series.AddLibrariesToPresentationUniqueKey");
+
+                var apiAssembly = Assembly.Load("Emby.Api");
+                var itemRefreshServiceType = apiAssembly?.GetType("Emby.Api.ItemRefreshService");
+                var refreshItemType = apiAssembly?.GetType("Emby.Api.RefreshItem");
+                if (itemRefreshServiceType == null)
+                {
+                    FailInitialization("Emby.Api.ItemRefreshService 类型缺失");
+                    return;
+                }
+
+                if (refreshItemType == null)
+                {
+                    FailInitialization("Emby.Api.RefreshItem 类型缺失");
+                    return;
+                }
+
+                getRefreshOptions = PatchMethodResolver.Resolve(
+                    itemRefreshServiceType,
+                    apiAssembly?.GetName().Version,
+                    new MethodSignatureProfile
+                    {
+                        Name = "itemrefresh-getoptions-exact",
+                        MethodName = "GetRefreshOptions",
+                        BindingFlags = BindingFlags.Instance | BindingFlags.NonPublic,
+                        ParameterTypes = new[] { refreshItemType },
+                        ReturnType = typeof(MetadataRefreshOptions)
+                    },
+                    logger,
+                    "MergeMultiVersion.ItemRefreshService.GetRefreshOptions");
+
+                if (isEligibleForMultiVersion == null)
+                {
+                    FailInitialization("IsEligibleForMultiVersion 缺失");
+                    return;
+                }
+
+                if (canRefreshImage == null)
+                {
+                    FailInitialization("CanRefresh(IImageProvider, BaseItem, LibraryOptions, ImageRefreshOptions, bool, bool) 缺失");
+                    return;
+                }
+
+                if (addLibrariesToPresentationUniqueKey == null)
+                {
+                    FailInitialization("Series.AddLibrariesToPresentationUniqueKey 缺失");
+                    return;
+                }
+
+                if (getRefreshOptions == null)
+                {
+                    FailInitialization("GetRefreshOptions 缺失");
+                    return;
+                }
+
+                harmony = new Harmony("mediainfokeeper.mergemultiversion");
+
+                if (isEnabled)
+                {
+                    Patch();
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.Error("MergeMultiVersion 初始化失败。");
+                logger?.Error(ex.Message);
+                logger?.Error(ex.ToString());
+                harmony = null;
+                isPatched = false;
+                isEnabled = false;
+            }
+        }
+
+        private static void FailInitialization(string reason)
+        {
+            PatchLog.InitFailed(logger, nameof(MergeMultiVersion), reason);
+            harmony = null;
+            isPatched = false;
+            isEnabled = false;
+        }
+
+        public static void Configure(bool enable, MergeSeriesScopeOption seriesPreference)
+        {
+            isEnabled = enable;
+            mergeSeriesPreference = seriesPreference;
+
+            if (harmony == null)
+            {
+                return;
+            }
+
+            if (isEnabled)
+            {
+                Patch();
+            }
+            else
+            {
+                Unpatch();
+            }
+        }
+
+        private static void Patch()
+        {
+            if (isPatched || harmony == null)
+            {
+                return;
+            }
+
+            if (isEligibleForMultiVersion != null)
+            {
+                harmony.Patch(
+                    isEligibleForMultiVersion,
+                    prefix: new HarmonyMethod(typeof(MergeMultiVersion), nameof(IsEligibleForMultiVersionPrefix)));
+                PatchLog.Patched(logger, nameof(MergeMultiVersion), isEligibleForMultiVersion);
+            }
+
+            if (canRefreshImage != null)
+            {
+                harmony.Patch(
+                    canRefreshImage,
+                    prefix: new HarmonyMethod(typeof(MergeMultiVersion), nameof(CanRefreshImagePrefix)));
+                PatchLog.Patched(logger, nameof(MergeMultiVersion), canRefreshImage);
+            }
+
+            if (addLibrariesToPresentationUniqueKey != null)
+            {
+                harmony.Patch(
+                    addLibrariesToPresentationUniqueKey,
+                    prefix: new HarmonyMethod(typeof(MergeMultiVersion),
+                        nameof(AddLibrariesToPresentationUniqueKeyPrefix)));
+                PatchLog.Patched(logger, nameof(MergeMultiVersion), addLibrariesToPresentationUniqueKey);
+            }
+
+            if (getRefreshOptions != null)
+            {
+                harmony.Patch(
+                    getRefreshOptions,
+                    postfix: new HarmonyMethod(typeof(MergeMultiVersion),
+                        nameof(GetRefreshOptionsPostfix)));
+                PatchLog.Patched(logger, nameof(MergeMultiVersion), getRefreshOptions);
+            }
+
+            isPatched = true;
+        }
+
+        private static void Unpatch()
+        {
+            if (!isPatched || harmony == null)
+            {
+                return;
+            }
+
+            if (isEligibleForMultiVersion != null)
+            {
+                harmony.Unpatch(isEligibleForMultiVersion, HarmonyPatchType.Prefix, harmony.Id);
+            }
+
+            if (canRefreshImage != null)
+            {
+                harmony.Unpatch(canRefreshImage, HarmonyPatchType.Prefix, harmony.Id);
+            }
+
+            if (addLibrariesToPresentationUniqueKey != null)
+            {
+                harmony.Unpatch(addLibrariesToPresentationUniqueKey, HarmonyPatchType.Prefix, harmony.Id);
+            }
+
+            if (getRefreshOptions != null)
+            {
+                harmony.Unpatch(getRefreshOptions, HarmonyPatchType.Postfix, harmony.Id);
+            }
+
+            isPatched = false;
+        }
+
+        [HarmonyPrefix]
+        private static bool IsEligibleForMultiVersionPrefix(string folderName, string testFilename, ref bool __result)
+        {
+            __result = string.Equals(folderName, Path.GetFileName(Path.GetDirectoryName(testFilename)),
+                StringComparison.OrdinalIgnoreCase);
+
+            return false;
+        }
+
+        private static BaseItem[] GetAllCollectionFolders(Series series)
+        {
+            if (!(series.HasProviderId(MetadataProviders.Tmdb) || series.HasProviderId(MetadataProviders.Imdb) ||
+                  series.HasProviderId(MetadataProviders.Tvdb)))
+            {
+                return Array.Empty<BaseItem>();
+            }
+
+            var allSeries = BaseItem.LibraryManager.GetItemList(new InternalItemsQuery
+            {
+                EnableTotalRecordCount = false,
+                Recursive = false,
+                ExcludeItemIds = new[] { series.InternalId },
+                IncludeItemTypes = new[] { nameof(Series) },
+                AnyProviderIdEquals = new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>(MetadataProviders.Tmdb.ToString(),
+                        series.GetProviderId(MetadataProviders.Tmdb)),
+                    new KeyValuePair<string, string>(MetadataProviders.Imdb.ToString(),
+                        series.GetProviderId(MetadataProviders.Imdb)),
+                    new KeyValuePair<string, string>(MetadataProviders.Tvdb.ToString(),
+                        series.GetProviderId(MetadataProviders.Tvdb))
+                }
+            }).Concat(new[] { series }).ToList();
+
+            var collectionFolders = new HashSet<BaseItem>();
+
+            foreach (var item in allSeries)
+            {
+                var options = BaseItem.LibraryManager.GetLibraryOptions(item);
+
+                if (options.EnableAutomaticSeriesGrouping)
+                {
+                    foreach (var library in BaseItem.LibraryManager.GetCollectionFolders(item))
+                    {
+                        collectionFolders.Add(library);
+                    }
+                }
+            }
+
+            return collectionFolders.OrderBy(c => c.InternalId).ToArray();
+        }
+
+        [HarmonyPrefix]
+        private static void CanRefreshImagePrefix(IImageProvider provider, BaseItem item, LibraryOptions libraryOptions,
+            ImageRefreshOptions refreshOptions, bool ignoreMetadataLock, bool ignoreLibraryOptions)
+        {
+            if (currentAllCollectionFolders.Value != null)
+            {
+                return;
+            }
+
+            if (item.Parent is null && item.ExtraType is null)
+            {
+                return;
+            }
+
+            if (item is Series series && mergeSeriesPreference == MergeSeriesScopeOption.GlobalScope)
+            {
+                currentAllCollectionFolders.Value = GetAllCollectionFolders(series);
+            }
+        }
+
+        [HarmonyPrefix]
+        private static bool AddLibrariesToPresentationUniqueKeyPrefix(Series __instance, string key,
+            ref BaseItem[] collectionFolders, LibraryOptions libraryOptions, IDataContext dataContext,
+            ref string __result)
+        {
+            if (currentAllCollectionFolders.Value != null)
+            {
+                if (currentAllCollectionFolders.Value.Length > 1)
+                {
+                    collectionFolders = currentAllCollectionFolders.Value;
+                }
+
+                currentAllCollectionFolders.Value = null;
+            }
+
+            return true;
+        }
+
+        [HarmonyPostfix]
+        private static void GetRefreshOptionsPostfix(IReturnVoid request, MetadataRefreshOptions __result)
+        {
+            var id = Traverse.Create(request).Property("Id").GetValue<string>();
+            var item = BaseItem.LibraryManager.GetItemById(id);
+
+            if (item is Series || item is Season)
+            {
+                var series = item as Series ?? (item as Season).Series;
+                var seriesTmdbId = series?.GetProviderId(MetadataProviders.Tmdb);
+                var episodeGroupId = series?.GetProviderId(MovieDbEpisodeGroupExternalId.StaticName)?.Trim();
+
+                var itemsToRefresh = BaseItem.LibraryManager.GetItemList(new InternalItemsQuery
+                {
+                    PresentationUniqueKey = item.PresentationUniqueKey,
+                    ExcludeItemIds = new[] { item.InternalId }
+                });
+
+                foreach (var alt in itemsToRefresh)
+                {
+                    if (!string.IsNullOrEmpty(episodeGroupId))
+                    {
+                        var altSeries = alt as Series ?? (alt as Season)?.Series;
+
+                        if (altSeries != null)
+                        {
+                            var altSeriesTmdbId = altSeries.GetProviderId(MetadataProviders.Tmdb);
+                            var altEpisodeGroupId = altSeries.GetProviderId(MovieDbEpisodeGroupExternalId.StaticName);
+                            if (string.IsNullOrEmpty(altEpisodeGroupId) && !string.IsNullOrEmpty(seriesTmdbId) &&
+                                !string.IsNullOrEmpty(altSeriesTmdbId) && string.Equals(seriesTmdbId, altSeriesTmdbId,
+                                    StringComparison.OrdinalIgnoreCase))
+                            {
+                                alt.SetProviderId(MovieDbEpisodeGroupExternalId.StaticName, episodeGroupId);
+                                alt.UpdateToRepository(ItemUpdateType.MetadataEdit);
+                            }
+                        }
+                    }
+
+                    BaseItem.ProviderManager.QueueRefresh(alt.InternalId, __result, RefreshPriority.Normal, true);
+                }
+            }
+        }
+    }
+}

--- a/Patch/PatchManager.cs
+++ b/Patch/PatchManager.cs
@@ -556,6 +556,33 @@ namespace MediaInfoKeeper.Patch
 
             registrations.Add(new PatchRegistration
             {
+                Name = "MergeMultiVersion",
+                Initialize = options =>
+                {
+                    options.Enhance ??= new EnhanceOptions();
+                    MergeMultiVersion.Initialize(
+                        logger,
+                        IsPluginEnabled(options) && options.Enhance.MergeMultiVersion,
+                        options.Enhance.MergeSeriesPreference);
+                },
+                Configure = options =>
+                {
+                    options.Enhance ??= new EnhanceOptions();
+                    MergeMultiVersion.Configure(
+                        IsPluginEnabled(options) && options.Enhance.MergeMultiVersion,
+                        options.Enhance.MergeSeriesPreference);
+                },
+                IsEnabled = options =>
+                {
+                    options.Enhance ??= new EnhanceOptions();
+                    return IsPluginEnabled(options) && options.Enhance.MergeMultiVersion;
+                },
+                IsReady = () => MergeMultiVersion.IsReady,
+                IsWaiting = () => false
+            });
+
+            registrations.Add(new PatchRegistration
+            {
                 Name = "LibrayProviderSettings",
                 Initialize = options => LibrayProviderSettings.Initialize(
                     logger,

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -28,13 +28,19 @@ using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Activity;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Drawing;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Events;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Logging;
 using MediaBrowser.Model.Plugins.UI;
 using MediaBrowser.Model.Serialization;
+using MediaBrowser.Model.Tasks;
 using MediaInfoKeeper.Web;
+using MediaInfoKeeper.ScheduledTask;
+using static MediaInfoKeeper.Options.EnhanceOptions;
 
 namespace MediaInfoKeeper
 {
@@ -77,6 +83,7 @@ namespace MediaInfoKeeper
         private readonly ISessionManager sessionManager;
         private readonly IMediaMountManager mediaMountManager;
         private readonly IApplicationHost applicationHost;
+        private readonly ITaskManager taskManager;
         private readonly ReleaseInfoService releaseInfoService;
 
         internal static IProviderManager ProviderManager { get; private set; }
@@ -135,6 +142,7 @@ namespace MediaInfoKeeper
             this.userDataManager = userDataManager;
             this.sessionManager = sessionManager;
             this.mediaMountManager = mediaMountManager;
+            this.taskManager = applicationHost.Resolve<ITaskManager>();
             this.releaseInfoService = new ReleaseInfoService(httpClient, this.logger, () => this.Options);
             ReleaseInfoService = this.releaseInfoService;
             ProviderManager = providerManager;
@@ -201,6 +209,8 @@ namespace MediaInfoKeeper
             this.libraryManager.ItemAdded += this.OnItemAdded;
             this.libraryManager.ItemRemoved += this.OnItemRemoved;
             this.userDataManager.UserDataSaved += this.OnUserDataSaved;
+            this.providerManager.RefreshCompleted += this.OnRefreshCompleted;
+            CollectionFolder.LibraryOptionsUpdated += this.OnLibraryOptionsUpdated;
 
             this.logger.Info($"插件 {this.Name} 加载完成");
         }
@@ -814,6 +824,68 @@ namespace MediaInfoKeeper
             MediaInfoDocument.DeleteMediaInfoJson(e.Item, new DirectoryService(this.logger, this.fileSystem), "Item Removed Event");
         }
 
+        private void OnRefreshCompleted(object sender, GenericEventArgs<RefreshProgressInfo> e)
+        {
+            if (this.libraryManager.IsScanRunning)
+            {
+                return;
+            }
+
+            var options = this.Options;
+            var item = e.Argument.Item;
+            if (!(options.Enhance?.MergeMultiVersion == true && item.IsTopParent))
+            {
+                return;
+            }
+
+            if (MergeMultiVersionTask.IsInternalRefresh(item.InternalId))
+            {
+                return;
+            }
+
+            var library = e.Argument.CollectionFolders.OfType<CollectionFolder>().FirstOrDefault();
+
+            if (library == null)
+            {
+                return;
+            }
+
+            var mergeSeriesPreference = options.Enhance.MergeSeriesPreference;
+            if (!(library.CollectionType == CollectionType.Movies.ToString() ||
+                  library.CollectionType == CollectionType.TvShows.ToString() &&
+                  mergeSeriesPreference == MergeSeriesScopeOption.GlobalScope ||
+                  library.CollectionType is null))
+            {
+                return;
+            }
+
+            MergeMultiVersionTask.currentScanLibrary.Value = library;
+
+            var mergeMoviesTask = this.taskManager.ScheduledTasks.FirstOrDefault(t =>
+                t.ScheduledTask is MergeMultiVersionTask);
+
+            if (mergeMoviesTask != null && MergeMultiVersionTask.TryBeginTriggeredExecution())
+            {
+                _ = this.taskManager.Execute(mergeMoviesTask, new TaskOptions());
+            }
+        }
+
+        private void OnLibraryOptionsUpdated(object sender, GenericEventArgs<Tuple<CollectionFolder, LibraryOptions>> e)
+        {
+            if (this.Options.Enhance?.MergeMultiVersion != true)
+            {
+                return;
+            }
+
+            var library = e.Argument.Item1;
+
+            if (library.CollectionType == CollectionType.TvShows.ToString() ||
+                library.CollectionType is null)
+            {
+                LibraryService.EnsureLibraryEnabledAutomaticSeriesGrouping();
+            }
+        }
+
         private string GetCurrentVersion()
         {
             var releaseTag = GetAssemblyReleaseTag(this.GetType().Assembly);
@@ -885,6 +957,8 @@ namespace MediaInfoKeeper
             this.libraryManager.ItemAdded -= this.OnItemAdded;
             this.libraryManager.ItemRemoved -= this.OnItemRemoved;
             this.userDataManager.UserDataSaved -= this.OnUserDataSaved;
+            this.providerManager.RefreshCompleted -= this.OnRefreshCompleted;
+            CollectionFolder.LibraryOptionsUpdated -= this.OnLibraryOptionsUpdated;
             this.releaseInfoService.Dispose();
             PrefetchService?.Dispose();
             StrmFileWatcher?.Dispose();

--- a/ScheduledTask/DownloadDanmuXmlTask.cs
+++ b/ScheduledTask/DownloadDanmuXmlTask.cs
@@ -24,7 +24,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "MediaInfoKeeperDownloadDanmuXmlTask";
 
-        public string Name => "7.下载弹幕";
+        public string Name => "07.下载弹幕";
 
         public string Description => "按本任务配置的媒体库范围与最近入库时间窗口，为电影和剧集下载弹幕。";
 

--- a/ScheduledTask/EmbyDllMethodsScanTask.cs
+++ b/ScheduledTask/EmbyDllMethodsScanTask.cs
@@ -33,7 +33,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "MediaInfoKeeperEmbyDllMethodsScanTask";
 
-        public string Name => "0.导出Emby DLL 方法";
+        public string Name => "00.导出Emby DLL 方法";
 
         public string Description => "扫描 Emby /system 下 DLL 并导出方法清单到 TXT。";
 

--- a/ScheduledTask/ExportExistingMediaInfoTask.cs
+++ b/ScheduledTask/ExportExistingMediaInfoTask.cs
@@ -19,7 +19,7 @@ namespace MediaInfoKeeper.ScheduledTask
         }
         public string Key => "MediaInfoKeeperExportExistingMediaInfoTask";
 
-        public string Name => "5.备份媒体信息";
+        public string Name => "05.备份媒体信息";
 
         public string Description => "按本任务配置的媒体库范围，将已存在 MediaInfo 的条目导出为 JSON，无 MediaInfo 则跳过。";
 

--- a/ScheduledTask/ExtractRecentMediaInfoTask.cs
+++ b/ScheduledTask/ExtractRecentMediaInfoTask.cs
@@ -27,7 +27,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "MediaInfoKeeperExtractRecentMediaInfoTask";
 
-        public string Name => "4.提取媒体信息";
+        public string Name => "04.提取媒体信息";
 
         public string Description => "按本任务配置的媒体库范围，取最近条目提取媒体信息并写入 JSON。（已存在则恢复）";
 

--- a/ScheduledTask/MergeMultiVersionTask.cs
+++ b/ScheduledTask/MergeMultiVersionTask.cs
@@ -1,0 +1,481 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HarmonyLib;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Logging;
+using MediaBrowser.Model.Tasks;
+using MediaInfoKeeper.Common;
+using static MediaInfoKeeper.Options.EnhanceOptions;
+
+namespace MediaInfoKeeper.ScheduledTask
+{
+    public class MergeMultiVersionTask : IScheduledTask, IConfigurableScheduledTask
+    {
+        private readonly ILogger logger;
+        private readonly ILibraryManager libraryManager;
+        private readonly IProviderManager providerManager;
+        private readonly IFileSystem fileSystem;
+
+        private static readonly HashSet<string> ProviderIdCheckKeys =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "tmdb", "imdb", "tvdb" };
+
+        public static readonly AsyncLocal<CollectionFolder> currentScanLibrary = new AsyncLocal<CollectionFolder>();
+        private static int isTriggeredExecutionRunning;
+        private static readonly object internalRefreshLock = new object();
+        private static readonly HashSet<long> internalRefreshItemIds = new HashSet<long>();
+
+        public MergeMultiVersionTask(
+            ILogManager logManager,
+            ILibraryManager libraryManager,
+            IProviderManager providerManager,
+            IFileSystem fileSystem)
+        {
+            this.logger = logManager.GetLogger(Plugin.PluginName);
+            this.libraryManager = libraryManager;
+            this.providerManager = providerManager;
+            this.fileSystem = fileSystem;
+        }
+
+        public string Key => "MergeMultiVersionTask";
+
+        public string Name => "10.合并多版本";
+
+        public string Description => "按偏好设置合并同一电影/电视剧的多个版本，支持跨媒体库操作。";
+
+        public string Category => Plugin.TaskCategoryName;
+
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            return Array.Empty<TaskTriggerInfo>();
+        }
+
+        public bool IsHidden => false;
+
+        public bool IsEnabled => true;
+
+        public bool IsLogged => true;
+
+        public async Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
+        {
+            this.logger.Info("MergeMultiVersion - 计划任务执行");
+
+            var currentScanLibraryValue = currentScanLibrary.Value;
+            currentScanLibrary.Value = null;
+
+            try
+            {
+                double cumulativeProgress = 0;
+
+                var seriesLibraryGroups = PrepareMergeSeries();
+                var movieLibraryGroups = PrepareMergeMovies(currentScanLibraryValue);
+
+                var processSeries = seriesLibraryGroups.Any() && (currentScanLibraryValue is null ||
+                                                                  currentScanLibraryValue.CollectionType == CollectionType.TvShows.ToString() ||
+                                                                  currentScanLibraryValue.CollectionType is null);
+                var processMovies = movieLibraryGroups.Any() && (currentScanLibraryValue is null ||
+                                                                 currentScanLibraryValue.CollectionType == CollectionType.Movies.ToString() ||
+                                                                 currentScanLibraryValue.CollectionType is null);
+
+                if (processSeries)
+                {
+                    var multiply = processMovies ? 1 : 2;
+
+                    var alternativeSeries = FindDuplicateSeries(seriesLibraryGroups);
+                    progress.Report(cumulativeProgress += 5.0 * multiply);
+
+                    if (alternativeSeries.Any())
+                    {
+                        var seriesProgressWeight = 35.0 * multiply / alternativeSeries.Count;
+
+                        foreach (var series in alternativeSeries)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            var shouldRefresh = currentScanLibraryValue is null ||
+                                                this.libraryManager.GetCollectionFolders(series)
+                                                    .Any(c => c.InternalId != currentScanLibraryValue.InternalId);
+                            await RefreshSeriesAsync(series, cancellationToken, shouldRefresh).ConfigureAwait(false);
+
+                            cumulativeProgress += seriesProgressWeight;
+                            progress.Report(cumulativeProgress);
+                        }
+                    }
+                    else
+                    {
+                        cumulativeProgress += 35.0 * multiply;
+                        progress.Report(cumulativeProgress);
+                    }
+
+                    var inconsistentSeries = FindInconsistentSeries(seriesLibraryGroups);
+                    progress.Report(cumulativeProgress += 5.0 * multiply);
+
+                    if (inconsistentSeries.Any())
+                    {
+                        var seriesProgressWeight = 5.0 * multiply / inconsistentSeries.Count;
+
+                        foreach (var series in inconsistentSeries)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            await RefreshSeriesAsync(series, cancellationToken).ConfigureAwait(false);
+
+                            cumulativeProgress += seriesProgressWeight;
+                            progress.Report(cumulativeProgress);
+                        }
+                    }
+                    else
+                    {
+                        cumulativeProgress += 5.0 * multiply;
+                        progress.Report(cumulativeProgress);
+                    }
+                }
+
+                if (processMovies)
+                {
+                    var totalGroups = movieLibraryGroups.Length;
+                    var groupProgressWeight = processSeries ? 50.0 / totalGroups : 100.0 / totalGroups;
+
+                    foreach (var group in movieLibraryGroups)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var groupProgress = new Progress<double>(p =>
+                        {
+                            cumulativeProgress += p * groupProgressWeight / 100;
+                            progress.Report(cumulativeProgress);
+                        });
+
+                        ExecuteMergeMovies(group, groupProgress);
+                    }
+                }
+
+                progress.Report(100);
+                this.logger.Info("MergeMultiVersion - 计划任务完成");
+            }
+            finally
+            {
+                EndTriggeredExecution();
+            }
+        }
+
+        public static bool IsInternalRefresh(long itemInternalId)
+        {
+            lock (internalRefreshLock)
+            {
+                return internalRefreshItemIds.Remove(itemInternalId);
+            }
+        }
+
+        public static bool TryBeginTriggeredExecution()
+        {
+            return Interlocked.CompareExchange(ref isTriggeredExecutionRunning, 1, 0) == 0;
+        }
+
+        private long[] PrepareMergeSeries()
+        {
+            var mergeSeriesPreference = Plugin.Instance.Options.Enhance?.MergeSeriesPreference
+                                        ?? MergeSeriesScopeOption.LibraryScope;
+            this.logger.Info("MergeMultiVersion - Merge Series Preference: " + mergeSeriesPreference);
+
+            if (mergeSeriesPreference != MergeSeriesScopeOption.GlobalScope)
+            {
+                return Array.Empty<long>();
+            }
+
+            var libraries = Plugin.LibraryService.GetSeriesLibraries()
+                .Where(l => l.GetLibraryOptions().EnableAutomaticSeriesGrouping)
+                .ToList();
+
+            if (!libraries.Any())
+            {
+                return Array.Empty<long>();
+            }
+
+            this.logger.Info("MergeMultiVersion - Series Libraries: " +
+                              string.Join(", ", libraries.Select(l => l.Name)));
+
+            return libraries.Select(l => l.InternalId).ToArray();
+        }
+
+        private List<Series> FindDuplicateSeries(long[] parents)
+        {
+            var allSeries = this.libraryManager.GetItemList(new InternalItemsQuery
+            {
+                Recursive = true,
+                ParentIds = parents,
+                IncludeItemTypes = new[] { nameof(Series) },
+                HasAnyProviderId = new[]
+                {
+                    MetadataProviders.Tmdb.ToString(), MetadataProviders.Imdb.ToString(),
+                    MetadataProviders.Tvdb.ToString()
+                }
+            }).ToList();
+
+            var dupSeries = allSeries
+                .SelectMany(item =>
+                    item.ProviderIds.Where(kvp => ProviderIdCheckKeys.Contains(kvp.Key))
+                        .Select(kvp => new { kvp.Key, kvp.Value, item }))
+                .GroupBy(x => new { x.Key, x.Value })
+                .Where(g =>
+                {
+                    var uniqueKeys = new HashSet<string>();
+                    foreach (var x in g)
+                    {
+                        uniqueKeys.Add(x.item.PresentationUniqueKey);
+                        if (uniqueKeys.Count > 1) return true;
+                    }
+
+                    return false;
+                })
+                .SelectMany(g => g.Select(x => x.item))
+                .GroupBy(item => item.InternalId)
+                .Select(g => g.First())
+                .OfType<Series>()
+                .ToList();
+
+            return dupSeries;
+        }
+
+        private List<Series> FindInconsistentSeries(long[] parents)
+        {
+            var allItems = this.libraryManager.GetItemList(new InternalItemsQuery
+            {
+                Recursive = true,
+                ParentIds = parents,
+                IncludeItemTypes = new[] { nameof(Season), nameof(Episode) },
+                GroupBySeriesPresentationUniqueKey = true
+            }).ToList();
+
+            var inconsistentSeries = allItems
+                .Select(item => new
+                {
+                    Series = (item as Season)?.Series ?? (item as Episode)?.Series,
+                    item.SeriesPresentationUniqueKey
+                })
+                .Where(x => x.Series != null && x.SeriesPresentationUniqueKey != x.Series.PresentationUniqueKey)
+                .GroupBy(x => x.Series.InternalId)
+                .Select(g => g.First().Series)
+                .ToList();
+
+            allItems.Clear();
+
+            return inconsistentSeries;
+        }
+
+        private long[][] PrepareMergeMovies(CollectionFolder currentScanLibrary)
+        {
+            var mergeMoviesPreference = Plugin.Instance.Options.Enhance?.MergeMoviesPreference
+                                        ?? MergeMoviesScopeOption.FolderScope;
+            this.logger.Info("MergeMultiVersion - Merge Movies Preference: " + mergeMoviesPreference);
+
+            var libraryGroups = Array.Empty<long[]>();
+
+            if (mergeMoviesPreference == MergeMoviesScopeOption.FolderScope)
+            {
+                return libraryGroups;
+            }
+
+            if (mergeMoviesPreference == MergeMoviesScopeOption.LibraryScope && currentScanLibrary != null)
+            {
+                libraryGroups = new[] { new[] { currentScanLibrary.InternalId } };
+                this.logger.Info("MergeMultiVersion - Movies Libraries: " + currentScanLibrary.Name);
+            }
+            else
+            {
+                var libraries = Plugin.LibraryService.GetMovieLibraries();
+
+                if (!libraries.Any())
+                {
+                    return libraryGroups;
+                }
+
+                this.logger.Info("MergeMultiVersion - Movies Libraries: " +
+                                  string.Join(", ", libraries.Select(l => l.Name)));
+
+                var libraryIds = libraries.Select(l => l.InternalId).ToArray();
+                libraryGroups = mergeMoviesPreference == MergeMoviesScopeOption.GlobalScope
+                    ? new[] { libraryIds }
+                    : libraryIds.Select(library => new[] { library }).ToArray();
+            }
+
+            return libraryGroups;
+        }
+
+        private void ExecuteMergeMovies(long[] parents, IProgress<double> groupProgress = null)
+        {
+            var allMovies = this.libraryManager.GetItemList(new InternalItemsQuery
+            {
+                Recursive = true,
+                ParentIds = parents,
+                IncludeItemTypes = new[] { nameof(Movie) },
+                HasAnyProviderId = new[]
+                {
+                    MetadataProviders.Tmdb.ToString(),
+                    MetadataProviders.Imdb.ToString(),
+                    MetadataProviders.Tvdb.ToString()
+                }
+            }).Cast<Movie>().ToList();
+
+            var dupMovies = allMovies
+                .SelectMany(item =>
+                    item.ProviderIds.Where(kvp => ProviderIdCheckKeys.Contains(kvp.Key))
+                        .Select(kvp => new { kvp.Key, kvp.Value, item }))
+                .GroupBy(kvp => new { kvp.Key, kvp.Value })
+                .Where(g =>
+                {
+                    var groupItems = g.Select(kvp => kvp.item).ToList();
+
+                    var altVersionCount = g.Sum(kvp =>
+                        kvp.item.GetAlternateVersionIds().Count(id =>
+                            groupItems.Any(i => i.InternalId == id)));
+
+                    return g.Count() != 1 + altVersionCount / g.Count();
+                })
+                .ToList();
+            allMovies.Clear();
+
+            if (dupMovies.Count > 0)
+            {
+                var parentMap = new Dictionary<long, long>(dupMovies.Count);
+
+                foreach (var group in dupMovies)
+                {
+                    long rootId = -1;
+
+                    foreach (var kvp in group)
+                    {
+                        var movie = kvp.item;
+
+                        if (!parentMap.ContainsKey(movie.InternalId))
+                        {
+                            parentMap[movie.InternalId] = movie.InternalId;
+                        }
+
+                        if (rootId == -1)
+                        {
+                            rootId = movie.InternalId;
+                        }
+                        else
+                        {
+                            UnionFindUtility.Union(rootId, movie.InternalId, parentMap);
+                        }
+                    }
+                }
+
+                var rootIdGroups = parentMap.Values
+                    .GroupBy(id => UnionFindUtility.Find(id, parentMap))
+                    .ToList();
+
+                var movieLookup = dupMovies.SelectMany(g => g)
+                    .GroupBy(kvp => UnionFindUtility.Find(kvp.item.InternalId, parentMap))
+                    .ToDictionary(d => d.Key,
+                        d => d.GroupBy(kvp => kvp.item.InternalId)
+                            .Select(g => g.First().item)
+                            .ToList());
+
+                var total = rootIdGroups.Count;
+                var current = 0;
+
+                foreach (var group in rootIdGroups)
+                {
+                    var movies = group
+                        .SelectMany(rootId =>
+                            movieLookup.TryGetValue(rootId, out var m)
+                                ? m
+                                : Enumerable.Empty<Movie>())
+                        .GroupBy(m => m.InternalId)
+                        .Select(g => g.First())
+                        .OfType<BaseItem>()
+                        .ToArray();
+
+                    this.libraryManager.MergeItems(movies);
+
+                    foreach (var movieItem in movies)
+                    {
+                        this.logger.Info("MergeMultiVersion - Movie 已合并: {0} - {1}",
+                            movieItem.Name, movieItem.Path);
+                    }
+
+                    current++;
+                    this.logger.Info("MergeMultiVersion - 已合并分组 {0}/{1}，共 {2} 项",
+                        current, total, movies.Length);
+
+                    groupProgress?.Report((double)current / total * 100);
+                }
+
+                groupProgress?.Report(100);
+            }
+        }
+
+        private MetadataRefreshOptions GetValidationRefreshOptions()
+        {
+            return new MetadataRefreshOptions(new DirectoryService(this.logger, this.fileSystem))
+            {
+                EnableRemoteContentProbe = false,
+                MetadataRefreshMode = MetadataRefreshMode.ValidationOnly,
+                ReplaceAllMetadata = false,
+                ImageRefreshMode = MetadataRefreshMode.ValidationOnly,
+                ReplaceAllImages = false,
+                EnableThumbnailImageExtraction = false,
+                EnableSubtitleDownloading = false
+            };
+        }
+
+        private async Task RefreshSeriesAsync(Series series, CancellationToken cancellationToken, bool shouldRefresh = true)
+        {
+            if (series == null)
+            {
+                return;
+            }
+
+            if (shouldRefresh)
+            {
+                var refreshOptions = GetValidationRefreshOptions();
+                Traverse.Create(refreshOptions).Property("Recursive").SetValue(true);
+                BeginInternalRefresh(series.InternalId);
+
+                try
+                {
+                    await this.providerManager.RefreshFullItem(series, refreshOptions, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    EndInternalRefresh(series.InternalId);
+                }
+            }
+
+            this.logger.Info("MergeMultiVersion - Series 已合并: {0} - {1}", series.Name, series.Path);
+        }
+
+        private static void BeginInternalRefresh(long itemInternalId)
+        {
+            lock (internalRefreshLock)
+            {
+                internalRefreshItemIds.Add(itemInternalId);
+            }
+        }
+
+        private static void EndInternalRefresh(long itemInternalId)
+        {
+            lock (internalRefreshLock)
+            {
+                internalRefreshItemIds.Remove(itemInternalId);
+            }
+        }
+
+        private static void EndTriggeredExecution()
+        {
+            Interlocked.Exchange(ref isTriggeredExecutionRunning, 0);
+        }
+    }
+}

--- a/ScheduledTask/RefreshRecentMetadataTask.cs
+++ b/ScheduledTask/RefreshRecentMetadataTask.cs
@@ -39,7 +39,7 @@ namespace MediaInfoKeeper.ScheduledTask
         }
         public string Key => "MediaInfoKeeperRefreshRecentMetadataTask";
 
-        public string Name => "2.刷新媒体元数据";
+        public string Name => "02.刷新媒体元数据";
 
         public string Description => "按本任务配置的媒体库范围与最近入库时间窗口筛选条目，刷新元数据（可选覆盖或补全），之后会从 JSON 恢复媒体信息。";
 

--- a/ScheduledTask/RestartEmbyTask.cs
+++ b/ScheduledTask/RestartEmbyTask.cs
@@ -21,7 +21,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "MediaInfoKeeperRestartEmbyTask";
 
-        public string Name => "9.重启Emby";
+        public string Name => "09.重启Emby";
 
         public string Description => "重启 Emby，临时释放内存。";
 

--- a/ScheduledTask/RestoreMediaInfoTask.cs
+++ b/ScheduledTask/RestoreMediaInfoTask.cs
@@ -24,7 +24,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "MediaInfoKeeperExtractMediaInfoTask";
 
-        public string Name => "6.恢复媒体信息";
+        public string Name => "06.恢复媒体信息";
 
         public string Description => "按本任务配置的媒体库范围，存在 JSON 则恢复媒体信息，不存在则跳过。";
 

--- a/ScheduledTask/ScanExternalFilesTask.cs
+++ b/ScheduledTask/ScanExternalFilesTask.cs
@@ -20,7 +20,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "MediaInfoKeeperScanExternalFilesTask";
 
-        public string Name => "8.扫描外挂文件";
+        public string Name => "08.扫描外挂文件";
 
         public string Description => "按本任务配置的媒体库范围独立扫描外挂文件，发现字幕或音轨变更时更新媒体流。";
 

--- a/ScheduledTask/ScanRecentIntroTask.cs
+++ b/ScheduledTask/ScanRecentIntroTask.cs
@@ -22,7 +22,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "MediaInfoKeeperScanRecentIntroTask";
 
-        public string Name => "3.扫描片头";
+        public string Name => "03.扫描片头";
 
         public string Description => "按本任务配置的媒体库范围，取最近条目的剧集执行片头检测。";
 

--- a/ScheduledTask/UpdatePluginTask.cs
+++ b/ScheduledTask/UpdatePluginTask.cs
@@ -34,7 +34,7 @@ namespace MediaInfoKeeper.ScheduledTask
 
         public string Key => "UpdatePluginTask";
 
-        public string Name => "1.更新插件";
+        public string Name => "01.更新插件";
 
         public string Description => "更新插件至最新版本";
 

--- a/Services/LibraryService.cs
+++ b/Services/LibraryService.cs
@@ -230,6 +230,46 @@ namespace MediaInfoKeeper.Services
             return NormalizeLibraryPaths(libraries.SelectMany(folder => folder.Locations ?? Array.Empty<string>()));
         }
 
+        public List<CollectionFolder> GetMovieLibraries()
+        {
+            var libraries = this.libraryManager
+                .GetItemList(new InternalItemsQuery { IncludeItemTypes = new[] { nameof(CollectionFolder) } })
+                .OfType<CollectionFolder>()
+                .Where(l => l.CollectionType == CollectionType.Movies.ToString() || l.CollectionType is null)
+                .ToList();
+
+            return libraries;
+        }
+
+        public List<CollectionFolder> GetSeriesLibraries()
+        {
+            var libraries = this.libraryManager
+                .GetItemList(new InternalItemsQuery { IncludeItemTypes = new[] { nameof(CollectionFolder) } })
+                .OfType<CollectionFolder>()
+                .Where(l => l.CollectionType == CollectionType.TvShows.ToString() || l.CollectionType is null)
+                .ToList();
+
+            return libraries;
+        }
+
+        public void EnsureLibraryEnabledAutomaticSeriesGrouping()
+        {
+            var libraries = this.libraryManager.GetVirtualFolders()
+                .Where(f => f.CollectionType == CollectionType.TvShows.ToString() || f.CollectionType is null)
+                .ToList();
+
+            foreach (var library in libraries)
+            {
+                var options = library.LibraryOptions;
+
+                if (!options.EnableAutomaticSeriesGrouping && long.TryParse(library.ItemId, out var itemId))
+                {
+                    options.EnableAutomaticSeriesGrouping = true;
+                    CollectionFolder.SaveLibraryOptions(itemId, options);
+                }
+            }
+        }
+
         /// <summary>获取所有媒体库的物理根路径。</summary>
         public List<string> GetAllLibraryPaths(bool existingOnly = true)
         {


### PR DESCRIPTION
1.跨媒体合并剧集、电影
2.计划任务编号改为双位数,避免“10.合并多版本”出现在“1.更新插件后”
已验证
<img width="1478" height="855" alt="截屏2026-06-04 10 27 33" src="https://github.com/user-attachments/assets/1f79935f-530d-4cd0-af74-9e64c296d1c8" />
<img width="1478" height="855" alt="截屏2026-06-04 10 27 47" src="https://github.com/user-attachments/assets/47a0be7d-ca17-47dd-a72b-dd75bd012520" />
<img width="1478" height="855" alt="截屏2026-06-04 10 27 55" src="https://github.com/user-attachments/assets/e199094c-1ac9-4e25-bdf7-6acd0147bbc3" />
